### PR TITLE
Added .idea/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+.idea/
 
 # JustCode is a .NET coding add-in
 .JustCode


### PR DESCRIPTION
The .idea/ directory is used by JetBrain's ReSharper plugin for visual studio, as well as JetBrains Rider IDE.

It's just a temp directory holding user specific IDE stuff, like which files are currently open (So they re-open between sessions).

It is safe to delete, and will be regenerated as-needed.