### PR TITLE
Fixed bug where if you specified a framerate, the elapsed time would …

### DIFF
--- a/PixelEngine/Game.cs
+++ b/PixelEngine/Game.cs
@@ -171,13 +171,13 @@ namespace PixelEngine
 			{
 				while (active)
 				{
+					if (frameTimer != null && !frameTimer.Tick())
+						continue;
+					
 					t2 = DateTime.Now;
 					Clock.Elapsed = t2 - t1;
 					float elapsed = (float)Clock.Elapsed.TotalSeconds;
 					t1 = t2;
-
-					if (frameTimer != null && !frameTimer.Tick())
-						continue;
 
 					if (delaying)
 					{


### PR DESCRIPTION
…be the last time since it skipped a frame, not the last time since an update was called.

This means, if you specified a framerate (ie: 60), update would be called every 1/60th of a second, but elapsed would be much smaller than 1/60. You can reproduce the problem with this sample game:

```
using PixelEngine;

namespace ChemistryWorld {
	public class PixelGame : Game {
		public static void Main(string[] args) {
			var pg = new PixelGame();
			pg.Construct(100, 100, 5, 5, 60);
			pg.Start();
		}
		
		private float Time = 0;
		
		public override void OnUpdate(float elapsed) {
			Clear(Pixel.Empty);

			Time += elapsed;
			DrawText(new Point(0, 0), "T: " + Time, Pixel.Presets.Red );
		}
	}
}
```

Before the fix, the timer would update very slowly. After the fix, it updates at a rate of about 1 per second (as to be expected).